### PR TITLE
Fix hardcoded paths

### DIFF
--- a/fogpy/test/test_fogpy.py
+++ b/fogpy/test/test_fogpy.py
@@ -100,8 +100,8 @@ prj = pyproj.Proj(proj='geos', lon_0=0.0, a=6378144.0, b=6356759.0,
 x_ll, y_ll = prj(3, 47)
 x_ur, y_ur = prj(19, 55)
 ger_extent = (x_ll, y_ll, x_ur, y_ur)
-germ_areadef = utils.load_area(os.path.join(os.getenv("PPP_CONFIG_DIR",
-                                                      "areas.yaml")),
+germ_areadef = utils.load_area(os.path.join(os.getenv("PPP_CONFIG_DIR"),
+                                                      "areas.yaml"),
                                'germ')
 germ_extent = germ_areadef.area_extent_ll
 x_ll, y_ll = prj(*germ_extent[0:2])

--- a/fogpy/test/test_fogpy.py
+++ b/fogpy/test/test_fogpy.py
@@ -100,7 +100,8 @@ prj = pyproj.Proj(proj='geos', lon_0=0.0, a=6378144.0, b=6356759.0,
 x_ll, y_ll = prj(3, 47)
 x_ur, y_ur = prj(19, 55)
 ger_extent = (x_ll, y_ll, x_ur, y_ur)
-germ_areadef = utils.load_area('/data/tleppelt/Pytroll/config/areas.def',
+germ_areadef = utils.load_area(os.path.join(os.getenv("PPP_CONFIG_DIR",
+                                                      "areas.yaml")),
                                'germ')
 germ_extent = germ_areadef.area_extent_ll
 x_ll, y_ll = prj(*germ_extent[0:2])

--- a/fogpy/utils/import_synop.py
+++ b/fogpy/utils/import_synop.py
@@ -51,7 +51,7 @@ def read_synop(file, params, min=None, max=None):
     Returns list of station dictionaries for given thresholds
     """
     result = {}
-    bfr = Bufr("libdwd", os.getenv["BUFR_TABLES"])
+    bfr = Bufr("libdwd", os.getenv("BUFR_TABLES"))
     for blob, size, header in load_file.next_bufr(file):
         bfr.decode(blob)
         try:
@@ -302,7 +302,7 @@ def read_swis(file, params, min=None, max=None, latlim=None, lonlim=None):
     Returns list of station dictionaries for given thresholds
     """
     result = {}
-    bfr = Bufr("libdwd", os.getenv("BUFR_TABLES")
+    bfr = Bufr("libdwd", os.getenv("BUFR_TABLES"))
     for blob, size, header in load_file.next_bufr(file):
         bfr.decode(blob)
         try:

--- a/fogpy/utils/import_synop.py
+++ b/fogpy/utils/import_synop.py
@@ -26,6 +26,7 @@ bufr file"""
 import fogpy
 import logging
 import os
+import os.path
 
 from fogpy.lowwatercloud import CloudLayer as CL
 from trollbufr.bufr import Bufr
@@ -50,7 +51,7 @@ def read_synop(file, params, min=None, max=None):
     Returns list of station dictionaries for given thresholds
     """
     result = {}
-    bfr = Bufr("libdwd", "/data/tleppelt/git/trollbufr/")
+    bfr = Bufr("libdwd", os.getenv["BUFR_TABLES"])
     for blob, size, header in load_file.next_bufr(file):
         bfr.decode(blob)
         try:
@@ -169,7 +170,7 @@ def read_metar(file, params, min=None, max=None, latlim=None, lonlim=None):
     Returns list of station dictionaries for given thresholds
     """
     result = {}
-    bfr = Bufr("libdwd", "/data/tleppelt/git/trollbufr/")
+    bfr = Bufr("libdwd", os.getenv("BUFR_TABLES"))
     for blob, size, header in load_file.next_bufr(file):
         bfr.decode(blob)
         try:
@@ -301,7 +302,7 @@ def read_swis(file, params, min=None, max=None, latlim=None, lonlim=None):
     Returns list of station dictionaries for given thresholds
     """
     result = {}
-    bfr = Bufr("libdwd", "/data/tleppelt/git/trollbufr/")
+    bfr = Bufr("libdwd", os.getenv("BUFR_TABLES")
     for blob, size, header in load_file.next_bufr(file):
         bfr.decode(blob)
         try:


### PR DESCRIPTION
Change hardcoded paths to paths using environment variables.

There's still one referring to `/data/tleppelt/skydata/` that I don't yet know how to fix.