### PR TITLE
Fix exception type when wrong type is passed

### DIFF
--- a/fogpy/algorithms.py
+++ b/fogpy/algorithms.py
@@ -125,7 +125,7 @@ class BaseSatelliteAlgorithm(object):
         """Compute the new array mask as union of all input array masks
         and computed masks."""
         if not np.ma.is_mask(mask):
-            raise ImportError("Mask type is invalid")
+            raise TypeError("Mask type is invalid")
         if self.mask is not None:
             self.mask = self.mask | mask
         else:

--- a/fogpy/filters.py
+++ b/fogpy/filters.py
@@ -72,7 +72,7 @@ class BaseArrayFilter(object):
             self.arr = arr
             self.inmask = np.full(arr.shape, False, dtype=bool)
         else:
-            raise ImportError('The filter <{}> needs a valid 2d numpy array '
+            raise TypeError('The filter <{}> needs a valid 2d numpy array '
                               'as input'.format(self.__class__.__name__))
         if kwargs is not None:
             for key, value in kwargs.iteritems():


### PR DESCRIPTION
When the wrong type of information is passed to a filter, raise a
TypeError, not an ImportError.