### PR TITLE
Mark thin cbh optimize as known failure

### DIFF
--- a/fogpy/test/test_lowwatercloud.py
+++ b/fogpy/test/test_lowwatercloud.py
@@ -254,6 +254,7 @@ class Test_LowWaterCloud(unittest.TestCase):
         test = [round(i, 0) == 421 for i in listresult]
         self.assertGreaterEqual(sum(test), 8)
 
+    @unittest.expectedFailure
     def test_optimize_cbh_start_thin(self):
         self.thinlwc.thickness = 10.
         listresult = []


### PR DESCRIPTION
Considering #20, mark the thin cloud base height optimisation as an
expected failure.