### PR TITLE
Reset layers after minimisation

### DIFF
--- a/fogpy/lowwatercloud.py
+++ b/fogpy/lowwatercloud.py
@@ -550,7 +550,7 @@ class LowWaterCloud(object):
         # basin hopping it might, with brute force it won't), which was
         # triggering bug issue #29, therefore re-initialise layers with the
         # last value
-        self.init_cloud_layers(ret, self.thickness, True)
+        self.init_cloud_layers(result, self.thickness, True)
         # Add optional debug output
         if debug:
             for l in self.layers:

--- a/fogpy/lowwatercloud.py
+++ b/fogpy/lowwatercloud.py
@@ -544,6 +544,13 @@ class LowWaterCloud(object):
             ranges = slice(0, self.cth - self.upthres, 1)
             ret = brute(self.minimize_cbh, (ranges,), finish=None)
             result = ret
+        # the minimisation routine self.minimize_cbh calls
+        # self.init_cloud_layers, so in every call the cloud layers get reset;
+        # we don't know if the final call corresponded to the minimum (with
+        # basin hopping it might, with brute force it won't), which was
+        # triggering bug issue #29, therefore re-initialise layers with the
+        # last value
+        self.init_cloud_layers(ret, self.thickness, True)
         # Add optional debug output
         if debug:
             for l in self.layers:

--- a/fogpy/test/test_lowwatercloud.py
+++ b/fogpy/test/test_lowwatercloud.py
@@ -333,6 +333,28 @@ class Test_LowWaterCloud(unittest.TestCase):
         self.assertAlmostEqual(lwc.maxlwc, 0.494, 3)
         self.assertAlmostEqual(fbh, 612, 0)
 
+    def test_reset_layers_after_minimisation(self):
+        """Test that layers are properly reset after minimisation
+
+        Test for fix for #29
+        """
+        lwc = LowWaterCloud(1000., 275., 100., 100., 10e-6)
+
+        brb = lwc.optimize_cbh(lwc.cbh, method="brute")
+        lwc.init_cloud_layers(brb, lwc.thickness, True)
+        brl = lwc.layers
+        brfb = lwc.get_fog_base_height()
+
+        bhb = lwc.optimize_cbh(lwc.cbh, method="basin")
+        lwc.init_cloud_layers(bhb, lwc.thickness, True)
+        bhl = lwc.layers
+        bhfb = lwc.get_fog_base_height()
+
+        np.testing.assert_almost_equal(
+                [l.visibility for l in bhl if l.visibility is not None],
+                [l.visibility for l in brl if l.visibility is not None],
+                -1)
+        self.assertAlmostEqual(brfb, bhfb, 3)
 
 def suite():
     """The test suite for test_lowwatercloud.

--- a/fogpy/test/test_lowwatercloud.py
+++ b/fogpy/test/test_lowwatercloud.py
@@ -354,7 +354,7 @@ class Test_LowWaterCloud(unittest.TestCase):
                 [l.visibility for l in bhl if l.visibility is not None],
                 [l.visibility for l in brl if l.visibility is not None],
                 -1)
-        self.assertAlmostEqual(brfb, bhfb, 3)
+        self.assertAlmostEqual(brfb, bhfb, 0)
 
 def suite():
     """The test suite for test_lowwatercloud.

--- a/fogpy/test/test_lowwatercloud.py
+++ b/fogpy/test/test_lowwatercloud.py
@@ -341,12 +341,10 @@ class Test_LowWaterCloud(unittest.TestCase):
         lwc = LowWaterCloud(1000., 275., 100., 100., 10e-6)
 
         brb = lwc.optimize_cbh(lwc.cbh, method="brute")
-        lwc.init_cloud_layers(brb, lwc.thickness, True)
         brl = lwc.layers
         brfb = lwc.get_fog_base_height()
 
         bhb = lwc.optimize_cbh(lwc.cbh, method="basin")
-        lwc.init_cloud_layers(bhb, lwc.thickness, True)
         bhl = lwc.layers
         bhfb = lwc.get_fog_base_height()
 


### PR DESCRIPTION
The minimisation routine LowWaterCloud.minimize_cbh calls LowWaterCloud.init_cloud_layers, so in every round of the iterations the cloud layers get reset.  We don't know if the final call to the minimisation routine corresponds to the function minimum; for basin hopping it might, for brute force it likely won't.  This was triggering issue #29.  This PR re-initialises the layers with the final minimisation value.

Fixes #29.