### PR TITLE
Fix test in test_spatial_homogenity_filter_highsd

### DIFF
--- a/fogpy/test/test_filters.py
+++ b/fogpy/test/test_filters.py
@@ -491,7 +491,8 @@ class Test_SpatialHomogeneityFilter(unittest.TestCase):
                 msum += nval
 
         self.assertNotEqual(np.nansum(testfilter.mask), 0)
-        self.assertEqual(np.nansum(testfilter.mask), msum)
+        self.assertEqual(np.nansum(testfilter.mask),
+                np.count_nonzero(self.high_sd_clusterma.mask)+ msum)
 
     def test_spatial_homogenity_filter_maxsize(self):
         # Create cloud filter


### PR DESCRIPTION
Fix broken test in `Test_SpatialHomogeneityFilter.test_spatial_homogenity_filter_highsd`.
The reference `msum` was wrong, because it was not taking into account
values that were already masked to begin with.