### PR TITLE
Do not catch them all

### DIFF
--- a/fogpy/lowwatercloud.py
+++ b/fogpy/lowwatercloud.py
@@ -36,6 +36,9 @@ import numpy as np
 from scipy.optimize import basinhopping
 from scipy.optimize import brute
 
+class DummyException(Exception):
+    pass
+
 # Configure logger.
 logger = logging.getLogger('lowwatercloud')
 logging.basicConfig(format='%(asctime)s - %(name)s - %(levelname)s - '

--- a/fogpy/lowwatercloud.py
+++ b/fogpy/lowwatercloud.py
@@ -36,9 +36,6 @@ import numpy as np
 from scipy.optimize import basinhopping
 from scipy.optimize import brute
 
-class DummyException(Exception):
-    pass
-
 # Configure logger.
 logger = logging.getLogger('lowwatercloud')
 logging.basicConfig(format='%(asctime)s - %(name)s - %(levelname)s - '

--- a/fogpy/utils/import_synop.py
+++ b/fogpy/utils/import_synop.py
@@ -36,6 +36,8 @@ from datetime import datetime
 trollbufr_logger = logging.getLogger('trollbufr')
 trollbufr_logger.setLevel(logging.CRITICAL)
 
+class DummyException(Exception):
+    pass
 
 def read_synop(file, params, min=None, max=None):
     """ Reading bufr files for synoptical station data and provide dictionary
@@ -149,7 +151,7 @@ def read_synop(file, params, min=None, max=None):
                                            stationdict['altitude'],
                                            stationdict['lat'],
                                            stationdict['lon']] + paralist]
-        except Exception as e:
+        except DummyException as e:
             "ERROR: Unresolved station request: {}".format(e)
     return(result)
 
@@ -281,7 +283,7 @@ def read_metar(file, params, min=None, max=None, latlim=None, lonlim=None):
                                            stationdict['altitude'],
                                            stationdict['lat'],
                                            stationdict['lon']] + paralist]
-        except Exception as e:
+        except DummyException as e:
             "ERROR: Unresolved station request: {}".format(e)
     return(result)
 
@@ -420,7 +422,7 @@ def read_swis(file, params, min=None, max=None, latlim=None, lonlim=None):
                                            stationdict['altitude'],
                                            stationdict['lat'],
                                            stationdict['lon']] + paralist]
-        except Exception as e:
+        except DummyException as e:
             "ERROR: Unresolved station request: {}".format(e)
     return(result)
 


### PR DESCRIPTION
Do not use bare excepts and do not use `except Exception` under normal circumstances.
This PR instead creates a dummy class `DummyException`, that is never raised; like this I can debug in what contect those uncaught exceptions may occur.  Over time, those blocks should then be replaced again by narrow exceptions that may be expected.