### PR TITLE
Seed basin hopping minimisation

### DIFF
--- a/fogpy/lowwatercloud.py
+++ b/fogpy/lowwatercloud.py
@@ -522,7 +522,8 @@ class LowWaterCloud(object):
                                niter=30,
                                niter_success=5,
                                stepsize=200,
-                               accept_test=cbhbounds)
+                               accept_test=cbhbounds,
+                               seed=42)
             time_diff = int(round(time.time() * 1000)) - start_time
             result = float(ret.x[0])
             logger.info('Optimized lwp: start cbh: {:.2f}, cth: {:.2f}, '


### PR DESCRIPTION
Seed basin hopping minimisation for reproduceable results.  Without such
minimisation, the minimisation result may depend on the number of
threads used.  Threads starting at the same time will start with the
same random number generation in the basin hopping algorithm, thus the
same starting point and route, but if there are more clusters than
threads, some clusters will start when the first threads/clusters are
finished and will start with different random numbers, thus making the
result dependent on the number of threads.  By seeding the basin hopping
function every time, we make sure that there is no dependency of the
result on the number of threads.