### PR TITLE
Adapt fogpy attribute names

### DIFF
--- a/fogpy/composites.py
+++ b/fogpy/composites.py
@@ -121,9 +121,8 @@ class FogCompositor(satpy.composites.GenericCompositor):
         attrs = {k: projectables[0].attrs[k]
                  for k in ("satellite_longitude", "satellite_latitude",
                            "satellite_altitude", "sensor", "platform_name",
-                           "projection", "georef_offset_corrected",
-                           "navigation", "start_time", "end_time", "area",
-                           "resolution")}
+                           "orbital_parameters", "georef_offset_corrected",
+                           "start_time", "end_time", "area", "resolution")}
 
         xrfls = xarray.DataArray(
                 fls.data, dims=dims, coords=coords, attrs=attrs)


### PR DESCRIPTION
Adapt attribute names in the fogpy conversion helper to the changed names in satpy; those were changed in https://github.com/pytroll/satpy/pull/794 which broke fogpy (but are apparently not covered by unit tests...)