### PR TITLE
Get validation output for fog mask

### DIFF
--- a/fogpy/composites.py
+++ b/fogpy/composites.py
@@ -240,3 +240,31 @@ class FogCompositorNight(FogCompositor):
         (xrfls, xrmsk) = self._convert_ma_to_xr(projectables, fls, mask)
 
         return super().__call__((xrfls, xrmsk), *args, **kwargs)
+
+
+def save_extras(sc, fn):
+    """Save the `fls_days_extra` dataset to NetCDF
+
+    The ``fls_day_extra`` dataset as produced by the `FogCompositorDayExtra` and
+    loaded using ``.load(["fls_day_extra"])`` is unique in the sense that it is
+    an `xarray.Dataset` rather than an `xarray.DataArray`.  This means it can't
+    be stored with the usual satpy routines.  Because some of its attributes
+    contain special types, it can`t be stored with `Dataset.to_netcdf` either.
+
+    This function transfers the data variables as direct members of a new
+    `Scene` object and then use the `cf_writer` to write those to a NetCDF file.
+
+    Args:
+        sc : Scene
+            Scene object with the already loaded ``fls_day_extra`` "composite"
+        fn : str-like or path
+            Path to which to write NetCDF
+    """
+    s = Scene()
+    ds = sc["fls_day_extra"]
+    for k in ds.data_vars:
+        s[k] = ds[k]
+    s.save_datasets(
+            writer="cf",
+            datasets=ds.data_vars.keys(),
+            filename=str(fn))

--- a/fogpy/composites.py
+++ b/fogpy/composites.py
@@ -206,7 +206,9 @@ class FogCompositorDay(satpy.composites.GenericCompositor):
 
 class FogCompositorDayExtra(satpy.composites.GenericCompositor):
     def __call__(self, projectables, *args, **kwargs):
-        return projectables[0]
+        ds = projectables[0]
+        ds["standard_name"] = ds["name"] = "fls_day_extra"
+        return ds
 
 
 class FogCompositorNight(FogCompositor):

--- a/fogpy/composites.py
+++ b/fogpy/composites.py
@@ -204,6 +204,11 @@ class FogCompositorDay(satpy.composites.GenericCompositor):
         return super().__call__((ds["fls_day"], ds["fls_mask"]), *args, **kwargs)
 
 
+class FogCompositorDayExtra(satpy.composites.GenericCompositor):
+    def __call__(self, projectables, *args, **kwargs):
+        return projectables[0]
+
+
 class FogCompositorNight(FogCompositor):
 
     def __call__(self, projectables, *args, **kwargs):

--- a/fogpy/composites.py
+++ b/fogpy/composites.py
@@ -28,6 +28,7 @@ import numpy
 import xarray
 
 import satpy.composites
+import satpy.dataset
 import pyorbital.astronomy
 
 from satpy import Scene
@@ -185,6 +186,14 @@ class _IntermediateFogCompositorDay(FogCompositor):
             "cbh": xrcbh,
             "fbh": xrfbh,
             "lcthimg": xrlcth})
+
+        ds.attrs.update(satpy.dataset.combine_metadata(
+                xrfls.attrs, xrmsk.attrs, xrvmask.attrs,
+                xrcbh.attrs, xrfbh.attrs, xrlcth.attrs))
+
+        # NB: isn't this done somewhere more generically?
+        for k in ("standard_name", "name", "resolution"):
+            ds.attrs[k] = self.attrs[k]
 
         return ds
 

--- a/fogpy/composites.py
+++ b/fogpy/composites.py
@@ -126,10 +126,14 @@ class FogCompositor(satpy.composites.GenericCompositor):
                            "start_time", "end_time", "area", "resolution")}
 
         das = [xarray.DataArray(
-               ma.data, dims=dims, coords=coords, attrs=attrs)
+                   ma.data if isinstance(ma, numpy.ma.MaskedArray) else ma,
+                   dims=dims, coords=coords, attrs=attrs)
                for ma in args]
         for (ma, da) in zip(args, das):
-            da.values[ma.mask] = fv
+            try:
+                da.values[ma.mask] = fv
+            except AttributeError:  # no mask
+                pass
             da.encoding["_FillValue"] = fv
 
         return das

--- a/fogpy/composites.py
+++ b/fogpy/composites.py
@@ -200,6 +200,10 @@ class _IntermediateFogCompositorDay(FogCompositor):
 
 class FogCompositorDay(satpy.composites.GenericCompositor):
     def __call__(self, projectables, *args, **kwargs):
+        # in the yaml file, fls_day has as a single prerequisite
+        # _intermediate_fls_day.  Therefore, the first and only
+        # projectable is actually a Dataset, and pass a DataArray
+        # to the superclass.__call__ method.
         ds = projectables[0]
         return super().__call__((ds["fls_day"], ds["fls_mask"]), *args, **kwargs)
 

--- a/fogpy/composites.py
+++ b/fogpy/composites.py
@@ -207,7 +207,7 @@ class FogCompositorDay(satpy.composites.GenericCompositor):
 class FogCompositorDayExtra(satpy.composites.GenericCompositor):
     def __call__(self, projectables, *args, **kwargs):
         ds = projectables[0]
-        ds["standard_name"] = ds["name"] = "fls_day_extra"
+        ds.attrs["standard_name"] = ds.attrs["name"] = "fls_day_extra"
         return ds
 
 

--- a/fogpy/etc/composites/seviri.yaml
+++ b/fogpy/etc/composites/seviri.yaml
@@ -30,3 +30,9 @@ composites:
     prerequisites:
       - _intermediate_fls_day
     standard_name: fls_day
+
+  fls_day_extra:
+    compositor: !!python/name:fogpy.composites.FogCompositorDayExtra
+    prerequisites:
+      - _intermediate_fls_day
+    standard_name: fls_day_extra

--- a/fogpy/etc/composites/seviri.yaml
+++ b/fogpy/etc/composites/seviri.yaml
@@ -9,8 +9,8 @@ composites:
       - IR_108
     standard_name: fls_night
 
-  fls_day:
-    compositor: !!python/name:fogpy.composites.FogCompositorDay
+  _intermediate_fls_day:
+    compositor: !!python/name:fogpy.composites._IntermediateFogCompositorDay
     prerequisites:
       - VIS006
       - VIS008
@@ -22,5 +22,11 @@ composites:
       - cmic_cot
       - cmic_lwp
       - cmic_reff
-    standard_name: fls_day
+    standard_name: _intermediate_fls_day
     path_dem: /media/nas/x21308/DEM/dem_eu_1km.tif
+
+  fls_day:
+    compositor: !!python/name:fogpy.composites.FogCompositorDay
+    prerequisites:
+      - _intermediate_fls_day
+    standard_name: fls_day

--- a/fogpy/test/test_composites.py
+++ b/fogpy/test/test_composites.py
@@ -1,13 +1,63 @@
 import pytest
 import numpy
+import datetime
+import functools
 from numpy import array
 from xarray import DataArray as xrda
 
 
 @pytest.fixture
 def fogpy_inputs():
+    import pyresample
+    fkattr = {
+            'satellite_longitude': 0.0,
+            'satellite_latitude': 0.0,
+            'satellite_altitude': 35785831.0,
+            'orbital_parameters': {
+                'projection_longitude': 0.0,
+                'projection_latitude': 0.0,
+                'projection_altitude': 35785831.0,
+                'satellite_nominal_longitude': 0.0,
+                'satellite_nominal_latitude': 0.0,
+                'satellite_actual_longitude': 0.0688189107392428,
+                'satellite_actual_latitude': 0.1640766475684642,
+                'satellite_actual_altitude': 35782769.05113167},
+            'sensor': 'seviri',
+            'platform_name': 'Meteosat-11',
+            'georef_offset_corrected': True,
+            'start_time': datetime.datetime(2020, 1, 6, 10, 0, 10, 604000),
+            'end_time': datetime.datetime(2020, 1, 6, 10, 12, 43, 608000),
+            'area': pyresample.AreaDefinition(
+                "germ",
+                "germ",
+                None,
+                {
+                    'a': '6378144',
+                    'b': '6356759',
+                    'lat_0': '90',
+                    'lat_ts': '50',
+                    'lon_0': '5',
+                    'no_defs': 'None',
+                    'proj': 'stere',
+                    'type': 'crs',
+                    'units': 'm',
+                    'x_0': '0',
+                    'y_0': '0'},
+                1024,
+                1024,
+                (-155100.4363, -4441495.3795, 868899.5637, -3417495.3795)),
+            'name': 'VIS006',
+            'resolution': 3000.403165817,
+            'calibration': 'reflectance',
+            'polarization': None,
+            'level': None,
+            'modifiers': (),
+            'ancillary_variables': []}
+
+    mk = functools.partial(xrda, dims=("x", "y"), attrs=fkattr)
+
     return dict(
-        ir08=xrda(
+        ir08=mk(
             array(
                 [
                     [267.781, 265.75, 265.234],
@@ -15,9 +65,8 @@ def fogpy_inputs():
                     [266.092, 266.771, 268.614],
                 ]
             ),
-            dims=("x", "y"),
         ),
-        ir139=xrda(
+        ir139=mk(
             array(
                 [
                     [274.07, 270.986, 269.281],
@@ -25,9 +74,8 @@ def fogpy_inputs():
                     [277.023, 279.663, 279.663],
                 ]
             ),
-            dims=("x", "y"),
         ),
-        vis008=xrda(
+        vis008=mk(
             array(
                 [
                     [9.814, 10.652, 11.251],
@@ -35,9 +83,8 @@ def fogpy_inputs():
                     [15.081, 16.158, 16.637],
                 ]
             ),
-            dims=("x", "y"),
         ),
-        nir016=xrda(
+        nir016=mk(
             array(
                 [
                     [9.439, 9.559, 10.156],
@@ -45,9 +92,8 @@ def fogpy_inputs():
                     [15.055, 16.25, 16.967],
                 ]
             ),
-            dims=("x", "y"),
         ),
-        vis006=xrda(
+        vis006=mk(
             array(
                 [
                     [8.614, 9.215, 9.615],
@@ -55,9 +101,8 @@ def fogpy_inputs():
                     [12.72, 13.422, 13.722],
                 ]
             ),
-            dims=("x", "y"),
         ),
-        ir087=xrda(
+        ir087=mk(
             array(
                 [
                     [265.139, 263.453, 262.67],
@@ -65,9 +110,8 @@ def fogpy_inputs():
                     [263.453, 264.071, 266.338],
                 ]
             ),
-            dims=("x", "y"),
         ),
-        ir120=xrda(
+        ir120=mk(
             array(
                 [
                     [266.903, 265.208, 264.694],
@@ -75,9 +119,8 @@ def fogpy_inputs():
                     [265.037, 265.037, 267.406],
                 ]
             ),
-            dims=("x", "y"),
         ),
-        elev=xrda(
+        elev=mk(
             array(
                 [
                     [319.481, 221.918, 300.449],
@@ -85,13 +128,11 @@ def fogpy_inputs():
                     [521.734, 520.214, 505.892],
                 ]
             ),
-            dims=("x", "y"),
         ),
-        cot=xrda(
+        cot=mk(
             array([[6.15, 10.98, 11.78], [13.92, 16.04, 7.93], [7.94, 10.01, 6.12]]),
-            dims=("x", "y"),
         ),
-        reff=xrda(
+        reff=mk(
             array(
                 [
                     [3.06e-06, 3.01e-06, 3.01e-06],
@@ -99,13 +140,11 @@ def fogpy_inputs():
                     [3.01e-06, 3.01e-06, 9.32e-06],
                 ]
             ),
-            dims=("x", "y"),
         ),
-        lwp=xrda(
+        lwp=mk(
             array([[0.013, 0.022, 0.024], [0.028, 0.032, 0.016], [0.016, 0.02, 0.038]]),
-            dims=("x", "y"),
         ),
-        lat=xrda(
+        lat=mk(
             array(
                 [
                     [50.669, 50.669, 50.67],
@@ -113,13 +152,11 @@ def fogpy_inputs():
                     [50.559, 50.56, 50.561],
                 ]
             ),
-            dims=("x", "y"),
         ),
-        lon=xrda(
+        lon=mk(
             array([[6.437, 6.482, 6.528], [6.428, 6.474, 6.52], [6.42, 6.466, 6.511]]),
-            dims=("x", "y"),
         ),
-        cth=xrda(
+        cth=mk(
             array(
                 [
                     [4400.0, 4200.0, 4000.0],
@@ -127,7 +164,6 @@ def fogpy_inputs():
                     [1600.0, 1000.0, 800.0],
                 ]
             ),
-            dims=("x", "y"),
         ),
     )
 
@@ -156,4 +192,4 @@ def test_convert_ma_to_xr(fogpy_inputs, fog_comp_base, fogpy_outputs):
             *fogpy_outputs)
     assert len(conv) == len(fogpy_outputs)
     assert all([isinstance(c, xrda) for c in conv])
-    assert numpy.array_equal(fogpy_outputs.data[0], conv[0].values)
+    assert numpy.array_equal(fogpy_outputs[0].data, conv[0].values)

--- a/fogpy/test/test_composites.py
+++ b/fogpy/test/test_composites.py
@@ -8,6 +8,7 @@ from numpy import array
 from xarray import Dataset, DataArray as xrda, open_dataset
 from unittest import mock
 
+
 @pytest.fixture
 def fkattr():
     import pyresample
@@ -184,8 +185,8 @@ def fog_comp_base():
 def fogpy_outputs():
     fls = numpy.ma.masked_array(
             numpy.arange(9).reshape((3, 3)),
-            (numpy.arange(9)%2).astype("?").reshape((3, 3)))
-    mask = (numpy.arange(9)%2).astype("?").reshape((3, 3))
+            (numpy.arange(9) % 2).astype("?").reshape((3, 3)))
+    mask = (numpy.arange(9) % 2).astype("?").reshape((3, 3))
     return (fls, mask)
 
 
@@ -209,7 +210,7 @@ def fog_comp_interim():
 def fog_extra():
     return {
             "vcloudmask": numpy.ma.masked_array(
-                data=[[True, True, True,], [False, False, True], [True, False, False]],
+                data=[[True, True, True], [False, False, True], [True, False, False]],
                 mask=numpy.zeros((3, 3), dtype="?"),
                 fill_value=True),
             "cbh": numpy.zeros((3, 3)),
@@ -321,4 +322,4 @@ def test_save_extras(fog_intermediate_dataset):
             ds.load()
             assert set(ds.data_vars.keys()) >= {
                     "vcloudmask", "fls_mask", "fbh", "cbh", "fls_day", "lcth"}
-            numpy.testing.assert_array_equal(ds["fbh"].values, numpy.zeros((3,3)))
+            numpy.testing.assert_array_equal(ds["fbh"].values, numpy.zeros((3, 3)))

--- a/fogpy/test/test_composites.py
+++ b/fogpy/test/test_composites.py
@@ -1,0 +1,159 @@
+import pytest
+import numpy
+from numpy import array
+from xarray import DataArray as xrda
+
+
+@pytest.fixture
+def fogpy_inputs():
+    return dict(
+        ir08=xrda(
+            array(
+                [
+                    [267.781, 265.75, 265.234],
+                    [266.771, 265.75, 266.432],
+                    [266.092, 266.771, 268.614],
+                ]
+            ),
+            dims=("x", "y"),
+        ),
+        ir139=xrda(
+            array(
+                [
+                    [274.07, 270.986, 269.281],
+                    [273.335, 275.477, 277.236],
+                    [277.023, 279.663, 279.663],
+                ]
+            ),
+            dims=("x", "y"),
+        ),
+        vis008=xrda(
+            array(
+                [
+                    [9.814, 10.652, 11.251],
+                    [11.49, 13.884, 15.799],
+                    [15.081, 16.158, 16.637],
+                ]
+            ),
+            dims=("x", "y"),
+        ),
+        nir016=xrda(
+            array(
+                [
+                    [9.439, 9.559, 10.156],
+                    [11.47, 13.86, 16.011],
+                    [15.055, 16.25, 16.967],
+                ]
+            ),
+            dims=("x", "y"),
+        ),
+        vis006=xrda(
+            array(
+                [
+                    [8.614, 9.215, 9.615],
+                    [9.916, 11.519, 12.921],
+                    [12.72, 13.422, 13.722],
+                ]
+            ),
+            dims=("x", "y"),
+        ),
+        ir087=xrda(
+            array(
+                [
+                    [265.139, 263.453, 262.67],
+                    [264.225, 263.141, 263.608],
+                    [263.453, 264.071, 266.338],
+                ]
+            ),
+            dims=("x", "y"),
+        ),
+        ir120=xrda(
+            array(
+                [
+                    [266.903, 265.208, 264.694],
+                    [265.55, 264.522, 265.379],
+                    [265.037, 265.037, 267.406],
+                ]
+            ),
+            dims=("x", "y"),
+        ),
+        elev=xrda(
+            array(
+                [
+                    [319.481, 221.918, 300.449],
+                    [388.51, 501.519, 431.15],
+                    [521.734, 520.214, 505.892],
+                ]
+            ),
+            dims=("x", "y"),
+        ),
+        cot=xrda(
+            array([[6.15, 10.98, 11.78], [13.92, 16.04, 7.93], [7.94, 10.01, 6.12]]),
+            dims=("x", "y"),
+        ),
+        reff=xrda(
+            array(
+                [
+                    [3.06e-06, 3.01e-06, 3.01e-06],
+                    [3.01e-06, 3.01e-06, 3.01e-06],
+                    [3.01e-06, 3.01e-06, 9.32e-06],
+                ]
+            ),
+            dims=("x", "y"),
+        ),
+        lwp=xrda(
+            array([[0.013, 0.022, 0.024], [0.028, 0.032, 0.016], [0.016, 0.02, 0.038]]),
+            dims=("x", "y"),
+        ),
+        lat=xrda(
+            array(
+                [
+                    [50.669, 50.669, 50.67],
+                    [50.614, 50.615, 50.616],
+                    [50.559, 50.56, 50.561],
+                ]
+            ),
+            dims=("x", "y"),
+        ),
+        lon=xrda(
+            array([[6.437, 6.482, 6.528], [6.428, 6.474, 6.52], [6.42, 6.466, 6.511]]),
+            dims=("x", "y"),
+        ),
+        cth=xrda(
+            array(
+                [
+                    [4400.0, 4200.0, 4000.0],
+                    [4200.0, 2800.0, 1200.0],
+                    [1600.0, 1000.0, 800.0],
+                ]
+            ),
+            dims=("x", "y"),
+        ),
+    )
+
+@pytest.fixture
+def fog_comp_base():
+    from fogpy.composites import FogCompositor
+    return FogCompositor(name="fls_day")
+
+@pytest.fixture
+def fogpy_outputs():
+    fls = numpy.ma.masked_array([[1, 2], [3, 4]], [[True, False], [False, False]])
+    mask = numpy.ma.masked_array([[True, False], [False, True]],
+                           [[True, False], [False, False]])
+    return (fls, mask)
+
+def test_convert_projectables(fogpy_inputs, fog_comp_base):
+    fi_ma = fog_comp_base._convert_projectables(
+            [fogpy_inputs["ir08"], fogpy_inputs["vis008"]])
+    assert len(fi_ma) == 2
+    assert all([isinstance(ma, numpy.ma.MaskedArray) for ma in fi_ma])
+    assert numpy.array_equal(fi_ma[0].data, fogpy_inputs["ir08"].values)
+
+def test_convert_ma_to_xr(fogpy_inputs, fog_comp_base, fogpy_outputs):
+    conv = fog_comp_base._convert_ma_to_xr(
+            [fogpy_inputs["ir08"], fogpy_inputs["vis008"]],
+            *fogpy_outputs)
+    assert len(conv) == len(fogpy_outputs)
+    assert all([isinstance(c, xrda) for c in conv])
+    assert numpy.array_equal(fogpy_outputs.data[0], conv[0].values)

--- a/fogpy/test/test_composites.py
+++ b/fogpy/test/test_composites.py
@@ -44,8 +44,8 @@ def fogpy_inputs():
                     'units': 'm',
                     'x_0': '0',
                     'y_0': '0'},
-                1024,
-                1024,
+                3,
+                3,
                 (-155100.4363, -4441495.3795, 868899.5637, -3417495.3795)),
             'name': 'VIS006',
             'resolution': 3000.403165817,
@@ -288,6 +288,8 @@ def test_fog_comp_day_extra(fog_comp_day_extra, fog_intermediate_dataset):
     assert isinstance(composite, Dataset)
 
 
-def test_fog_comp_night(fog_comp_night, fogpy_inputs):
-    composite = fog_comp_night([fogpy_inputs["ir039"], fogpy_inputs["ir108"]])
+def test_fog_comp_night(fog_comp_night, fogpy_inputs, fogpy_outputs):
+    with mock.patch("fogpy.composites.NightFogLowStratusAlgorithm") as fcN:
+        fcN.return_value.run.return_value = fogpy_outputs
+        composite = fog_comp_night([fogpy_inputs["ir039"], fogpy_inputs["ir108"]])
     assert isinstance(composite, xrda)


### PR DESCRIPTION
Add a new `fls_day_extras` composite, relying on an intermediate `_intermediate_fls_day`, that allows to provide extra (debug) information for the fog composite.  

Fixes #47.