### PR TITLE
Adapt compositor for new satpy dataid

### DIFF
--- a/fogpy/composites.py
+++ b/fogpy/composites.py
@@ -225,7 +225,7 @@ class _IntermediateFogCompositorDay(FogCompositor):
 
         # NB: isn't this done somewhere more generically?
         for k in ("standard_name", "name", "resolution"):
-            ds.attrs[k] = self.attrs[k]
+            ds.attrs[k] = self.attrs.get(k)
 
         return ds
 


### PR DESCRIPTION
With the upcoming satpy changes replacing datasetids by dataids (see https://github.com/pytroll/satpy/pull/1088), attributes on compositors are no longer guaranteed.  Adapt their copying to not assume they are present in the first place.