### PR TITLE
Update copyright notices, move AUTHORS to file

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -1,0 +1,11 @@
+# Project Contributors
+
+The following people have made contributions to this project:
+
+<!--- Use your GitHub account or any other personal reference URL --->
+<!--- If you wish to not use your real name, please use your github username --->
+<!--- The list should be alphabetical by last name if possible, with github usernames at the bottom --->
+<!--- See https://gist.github.com/djhoese/52220272ec73b12eb8f4a29709be110d for auto-generating parts of this list --->
+
+- [Gerrit Holl (gerritholl)](https://github.com/gerritholl)
+- [Thomas Leppelt (m4sth0)](https://github.com/m4sth0)

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -74,7 +74,7 @@ master_doc = 'index'
 
 # General information about the project.
 project = u'fogpy'
-copyright = u'2017, Thomas Leppelt'
+copyright = '2017-2020, Fogpy developers'
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the
@@ -224,7 +224,7 @@ latex_elements = {
 # (source start file, target name, title, author, documentclass [howto/manual]).
 latex_documents = [
   ('index', 'fogpy.tex', u'fogpy Documentation',
-   u'Thomas Leppelt', 'manual'),
+   'Fogpy developers', 'manual'),
 ]
 
 # The name of an image file (relative to this directory) to place at the top of
@@ -254,7 +254,7 @@ latex_documents = [
 # (source start file, name, description, authors, manual section).
 man_pages = [
     ('index', 'fogpy', u'fogpy Documentation',
-     [u'Thomas Leppelt'], 1)
+     [u'Fogpy developers'], 1)
 ]
 
 # If true, show URL addresses after external links.
@@ -268,7 +268,7 @@ man_pages = [
 #  dir menu entry, description, category)
 texinfo_documents = [
   ('index', 'fogpy', u'fogpy Documentation',
-   u'Thomas Leppelt', 'fogpy', 'One line description of project.',
+   u'Fogpy developers', 'fogpy', 'One line description of project.',
    'Miscellaneous'),
 ]
 

--- a/fogpy/__init__.py
+++ b/fogpy/__init__.py
@@ -1,9 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-# Copyright (c) 2017
-# Author(s):
-#   Thomas Leppelt <thomas.leppelt@dwd.de>
-#   Gerrit Holl    <gerrit.holl@dwd.de>
+# Copyright (c) 2017-2020 Fogpy developers
 
 # This file is part of the fogpy package.
 

--- a/fogpy/algorithms.py
+++ b/fogpy/algorithms.py
@@ -1,8 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-# Copyright (c) 2017
-# Author(s):
-#   Thomas Leppelt <thomas.leppelt@dwd.de>
+# Copyright (c) 2017-2020 Fogpy developers
 
 # This file is part of the fogpy package.
 

--- a/fogpy/composites.py
+++ b/fogpy/composites.py
@@ -1,8 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-# Copyright (c) 2017
-# Author(s):
-#   Thomas Leppelt <thomas.leppelt@dwd.de>
+# Copyright (c) 2017-2020 Fogpy developers
 
 # This file is part of the fogpy package.
 

--- a/fogpy/filters.py
+++ b/fogpy/filters.py
@@ -1,8 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-# Copyright (c) 2017
-# Author(s):
-#   Thomas Leppelt <thomas.leppelt@dwd.de>
+# Copyright (c) 2017-2020 Fogpy developers
 
 # This file is part of the fogpy package.
 

--- a/fogpy/lowwatercloud.py
+++ b/fogpy/lowwatercloud.py
@@ -1,8 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-# Copyright (c) 2017
-# Author(s):
-#   Thomas Leppelt <thomas.leppelt@dwd.de>
+# Copyright (c) 2017-2020 Fogpy developers
 
 # This file is part of the fogpy package.
 

--- a/fogpy/test/__init__.py
+++ b/fogpy/test/__init__.py
@@ -1,8 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-# Copyright (c) 2017
-# Author(s):
-#   Thomas Leppelt <thomas.leppelt@dwd.de>
+# Copyright (c) 2017-2020 Fogpy developers
 
 # This file is part of the fogpy package.
 

--- a/fogpy/test/test_algorithms.py
+++ b/fogpy/test/test_algorithms.py
@@ -1,9 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-# Copyright (c) 2017, 2020
-# Author(s):
-#   Thomas Leppelt <thomas.leppelt@dwd.de>
-#   Gerrit Holl <thomas.leppelt@dwd.de>
+# Copyright (c) 2017-2020 Fogpy developers
 
 # This file is part of the fogpy package.
 

--- a/fogpy/test/test_composites.py
+++ b/fogpy/test/test_composites.py
@@ -1,3 +1,22 @@
+#!/usr/bin/env python
+
+# Copyright (c) 2017-2020 Fogpy developers
+
+# This file is part of the fogpy package.
+
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 import pytest
 import numpy
 import datetime

--- a/fogpy/test/test_filters.py
+++ b/fogpy/test/test_filters.py
@@ -1,8 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-# Copyright (c) 2017
-# Author(s):
-#   Thomas Leppelt <thomas.leppelt@dwd.de>
+# Copyright (c) 2017-2020 Fogpy developers
 
 # This file is part of the fogpy package.
 

--- a/fogpy/test/test_lowwatercloud.py
+++ b/fogpy/test/test_lowwatercloud.py
@@ -1,8 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-# Copyright (c) 2017
-# Author(s):
-#   Thomas Leppelt <thomas.leppelt@dwd.de>
+# Copyright (c) 2017-2020 Fogpy developers
 
 # This file is part of the fogpy package.
 

--- a/fogpy/test/test_utils.py
+++ b/fogpy/test/test_utils.py
@@ -1,3 +1,19 @@
+# Copyright (c) 2017-2020 Fogpy developers
+
+# This file is part of the fogpy package.
+
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 import logging
 
 import pytest

--- a/fogpy/utils/__init__.py
+++ b/fogpy/utils/__init__.py
@@ -1,8 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-# Copyright (c) 2017-2020
-# Author(s):
-#   Thomas Leppelt <thomas.leppelt@dwd.de>, Gerrit Holl <gerrit.holl@dwd.de>
+# Copyright (c) 2017-2020 Fogpy developers
 
 # This file is part of the fogpy package.
 

--- a/fogpy/utils/add_synop.py
+++ b/fogpy/utils/add_synop.py
@@ -1,9 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-# Copyright (c) 2016
-
-# Author(s):
-#   Thomas Leppelt <thomas.leppelt@dwd.de>
+# Copyright (c) 2016-2020 Fogpy developers
 
 # This file is part of the fogpy package.
 

--- a/fogpy/utils/export_synop.py
+++ b/fogpy/utils/export_synop.py
@@ -1,9 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-# Copyright (c) 2017
-
-# Author(s):
-#   Thomas Leppelt <thomas.leppelt@dwd.de>
+# Copyright (c) 2017-2020 Fogpy developers
 
 # This file is part of the fogpy package.
 

--- a/fogpy/utils/import_synop.py
+++ b/fogpy/utils/import_synop.py
@@ -1,9 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-# Copyright (c) 2016
-
-# Author(s):
-#   Thomas Leppelt <thomas.leppelt@dwd.de>
+# Copyright (c) 2016-2020 Fogpy developers
 
 # This file is part of the fogpy package.
 

--- a/fogpy/utils/reproj_testdata.py
+++ b/fogpy/utils/reproj_testdata.py
@@ -1,8 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-# Copyright (c) 2017
-# Author(s):
-#   Thomas Leppelt <thomas.leppelt@dwd.de>
+# Copyright (c) 2017-2020 Fogpy developers
 
 # This file is part of the fogpy package.
 

--- a/fogpy/version.py
+++ b/fogpy/version.py
@@ -1,8 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-# Copyright (c) 2017
-# Author(s):
-#   Thomas Leppelt <thomas.leppelt@dwd.de>
+# Copyright (c) 2017-2020 Fogpy developers
 
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-# Copyright (c) 2017
-# Author(s):
-#   Thomas Leppelt <thomas.leppelt@dwd.de>
+# Copyright (c) 2017-2020 Fogpy developers
 
 # This file is part of the fogpy package.
 


### PR DESCRIPTION
Update copyright notices in every file to make sure they cover up to
2020.  Remove individual author listings per file, instead add all
authors to AUTHORS.md and write the authors as Fogpy developers in each
file.