### PR TITLE
First try at GitHub CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,32 @@
+name: Python package
+
+on:
+  - push
+  - pull_request
+
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [3.8, 3.9]
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install dependencies
+        run: |
+          conda install numpy scipy matplotlib satpy pyresample opencv coverage appdirs requests
+          python -m pip install --upgrade pip
+          pip install flake8 pytest trollimage pyorbital trollbufr opencv-contrib-python
+      - name: Install fogpy
+        run: |
+          pip install --no-deps -e .
+      - name: Test with pytest
+        run: |
+          pytest --cov=fogpy fogpy/test --cov-report=xml


### PR DESCRIPTION
Add a `workflows/ci.yaml` file in a first attempt to enable GitHub CI for fogpy, replacing Travis.

- [x] Closes #85 