### PR TITLE
Convert kdtree result to int

### DIFF
--- a/fogpy/algorithms.py
+++ b/fogpy/algorithms.py
@@ -1242,7 +1242,9 @@ class PanSharpeningAlgorithm(BaseSatelliteAlgorithm):
             col = index[1]
             # Query tree for neighbors
             queryresult = tree.query(np.array([[row, col]]), k=25)
-            neighs = tree.data[queryresult[1][0][1:]]
+            # explicitly convert to int64, see
+            # https://github.com/scipy/scipy/issues/14296
+            neighs = tree.data[queryresult[1][0][1:]].astype(np.int64)
             # Get channel values for neighbors
             chn_neigh = chn[tuple(neighs.T)].squeeze()
             # Get panchromatic channel values for neighbors

--- a/fogpy/test/test_filters.py
+++ b/fogpy/test/test_filters.py
@@ -6461,7 +6461,8 @@ class Test_LowCloudFilter(unittest.TestCase):
                           'reff': test_reff,
                           'elev': test_elev,
                           'clusters': test_clusters,
-                          'cth': test_cth}
+                          'cth': test_cth,
+                          "nprocs": 1}
 
     def tearDown(self):
         pass


### PR DESCRIPTION
Convert the result of the scipy kdtree search to int.  It's been giving
float since scipy 1.16.  See https://github.com/scipy/scipy/issues/14296.

This should fix at least some of #82.